### PR TITLE
Undefined error problem

### DIFF
--- a/javascripts/autoComplete.js
+++ b/javascripts/autoComplete.js
@@ -112,7 +112,6 @@ define('autocomplete', ['require', 'exports', 'module', 'ace/keyboard/hash_handl
             self.show();
             var count = self.compilation(editor.getCursorPosition());
             if(!(count > 0)){
-                self.hide();
                 return;
             }
             editor.keyBinding.addKeyboardHandler(self.handler);


### PR DESCRIPTION
The "active" method try to hide the popup for AutoCompletion propositions but self.hide() is undefined. In addition, It's not needed because "compilation" method will call "showCompilation" that will hide the popup if there's no propositions to show.
